### PR TITLE
Fix typo in README example message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Test build args are passed correctly
 
 
-## Example message
+## Example messagedhfhf
 
 ```
 {


### PR DESCRIPTION
Corrected a typo in the example message section.